### PR TITLE
bugfix: array_merge_recursive may cause duplicate config values

### DIFF
--- a/src/RpcServiceProvider.php
+++ b/src/RpcServiceProvider.php
@@ -66,11 +66,9 @@ class RpcServiceProvider extends ServiceProvider {
 
 	protected function mergeConfigFrom($path, $key='rpc')
 	{
-		$config = $this->app['config']->get($key, []);
-		$config_pkg = require $path;
-		$config = array_merge_recursive($config_pkg, $config);
+        $config = $this->app['config']->get($key, []);
 
-		$this->app['config']->set($key, $config);
+        $this->app['config']->set($key, array_merge(require $path, $config));
 	}
 
 	/**


### PR DESCRIPTION
after vendor:publish config files , mergeConfigFrom function use array_merge_recursive may cause duplicate config values result.

rpc.client config assoc become:
```
{
    "url":["http://dev-dbss.thebizark.com/jsonrpc","http://dev-dbss.thebizark.com/jsonrpc"],
    "timeout":[5,5],
    "headers":[],
    "username":[false,false],
    "password":[null,null],
    "debug":[false,false],
    "ssl_verify_peer":[true,true],
    "cache":[null,null],
    "cache_duration":[15,15]
}
```