### PR TITLE
change server facade into JsonRpcServer 

### DIFF
--- a/config/rpc.php
+++ b/config/rpc.php
@@ -35,6 +35,13 @@ return array(
         'ssl_verify_peer' => env('RPC_SSL', true),
 
         /**
+         * If the only argument passed to a function is an array
+         * assume it contains named arguments
+         *
+         */
+        'named_arguments' => false,
+
+        /**
          * Methods to Cache
          * '*' to allow all, and 'method_name' to single method
          */

--- a/src/RpcClientWrapper.php
+++ b/src/RpcClientWrapper.php
@@ -55,6 +55,7 @@ class RpcClientWrapper {
 
         $connection->ssl_verify_peer = $opts['ssl_verify_peer'];
         $connection->debug           = $opts['debug'];
+        $connection->named_arguments = isset($opts['named_arguments']) && $opts['named_arguments']===true;
 
         if (isset($opts['username']) && $opts['username']) {
             $connection->authentication($opts['username'], $opts['password']);
@@ -75,7 +76,7 @@ class RpcClientWrapper {
 
         return call_user_func_array(
                 [$this->connection(), 'execute'],
-                array_merge([$method], $params)
+                [$method,$params]
             );
     }
 

--- a/src/RpcServerFacade.php
+++ b/src/RpcServerFacade.php
@@ -5,6 +5,6 @@ use Illuminate\Support\Facades\Facade;
 
 class RpcServerFacade extends Facade {
 
-    protected static function getFacadeAccessor() { return 'RpcServer'; }
+    protected static function getFacadeAccessor() { return 'JsonRpcServer'; }
 
 }


### PR DESCRIPTION
change server facade into JsonRpcServer so we can change example serve code to:
```return RpcServer::attach(app(MyRpcMethods::class))->execute();```
bugfix 4 call rpc function with arguments :
should call with:
``` RpcClient::ping($msg);```
NOT
``` RpcClient::ping([$msg]);```

add config option:
named_arguments disabled by default.
